### PR TITLE
Fix #114, Disable Optimization for Carthage/xcodebuild

### DIFF
--- a/Carlos.xcodeproj/project.pbxproj
+++ b/Carlos.xcodeproj/project.pbxproj
@@ -1919,7 +1919,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "de.weltn24.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};


### PR DESCRIPTION
Fix #114 Build error by Carthage

Happened when trying to build Carlos via xcodebuild (which is used for carthage)
I don't know why it works, but I felt tiny bitcode glitch between NS*(Foundation) - Swift.