### PR TITLE
#154: Reifies batchAllGet into a CacheLevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.9
+
+**Breaking changes**
+- `batchGetAll` has been removed and replaced with a reified `BatchAllCache`
+
+**New Features**
+- It's now possible to lift a `CacheLevel` into one that operates on a sequence of keys and returns a sequence of values. You can use `allBatch` to create a concrete `BatchAllCache`. You can use `get` on this cache if you want to pass a list of keys and get the success callback when **all** of them succeed and the failure callback **as soon as one** of them fails (old behavior of `batchGetAll`), or you can compose or transform an `allBatch` cache just like any another `CacheLevel`. Consult the `README.md` for an example.
+
 ## 0.8
 
 **Breaking changes**

--- a/Carlos/BatchAllCache.swift
+++ b/Carlos/BatchAllCache.swift
@@ -1,0 +1,47 @@
+import PiedPiper
+
+/// A reified batchGetAll
+public struct BatchAllCache<KeySeq: SequenceType, Cache: CacheLevel where KeySeq.Generator.Element == Cache.KeyType>: CacheLevel {
+  /// A sequence of keys for the wrapped cache
+  public typealias KeyType = KeySeq
+  /// An array of output elements
+  public typealias OutputType = [Cache.OutputType]
+
+  private let cache: Cache
+
+  /**
+   Dispatch each key in the sequence in parallel
+   Merge the results -- if any key fails, it all fails
+  */
+  public func get(key: KeyType) -> Future<OutputType> {
+    return key.traverse(cache.get)
+  }
+
+  /**
+  Zip the keys with the values and set them all
+  */
+  public func set(value: OutputType, forKey key: KeyType) {
+    zip(key, value).forEach { (k, v) in
+      self.cache.set(v, forKey: k)
+    }
+  }
+
+  public func clear() {
+    cache.clear()
+  }
+
+  public func onMemoryWarning() {
+    cache.onMemoryWarning()
+  }
+}
+
+extension CacheLevel {
+  /**
+   Wrap a <K, V> cache into a <Sequence<K>, [V]> cache where
+   each k in Sequence<K> is dispatched in parallel and if any K fails,
+   it all fails
+   */
+  public func allBatch<KeySeq: SequenceType where KeySeq.Generator.Element == Self.KeyType>() -> BatchAllCache<KeySeq, Self>  {
+    return BatchAllCache(cache: self)
+  }
+}

--- a/Tests/BatchTests.swift
+++ b/Tests/BatchTests.swift
@@ -4,6 +4,137 @@ import Quick
 import Nimble
 import PiedPiper
 
+class BatchAllCacheTests: QuickSpec {
+  override func spec() {
+    let requestsCount = 5
+
+    var internalCache: CacheLevelFake<Int, String>!
+    var cache: BatchAllCache<[Int], CacheLevelFake<Int, String>>!
+    var resultingFuture: Future<[String]>!
+
+    beforeEach {
+      internalCache = CacheLevelFake<Int, String>()
+      cache = internalCache.allBatch()
+    }
+
+    describe("allBatch") {
+      var result: [String]!
+      var errors: [ErrorType]!
+      var canceled: Bool!
+
+      beforeEach {
+        errors = []
+        result = nil
+        canceled = false
+
+        resultingFuture = cache.get(Array(0..<requestsCount))
+          .onSuccess {
+            result = $0
+          }
+          .onFailure {
+            errors.append($0)
+          }
+          .onCancel {
+            canceled = true
+        }
+      }
+
+      it("should dispatch all of the requests to the underlying cache") {
+        expect(internalCache.numberOfTimesCalledGet).to(equal(requestsCount))
+      }
+
+      context("when one of the requests fails") {
+        beforeEach {
+          internalCache.promisesReturned[0].fail(TestError.SimpleError)
+        }
+
+        it("should fail the resulting future") {
+          expect(errors).notTo(beEmpty())
+        }
+
+        it("should pass the right error") {
+          expect(errors.first as? TestError).to(equal(TestError.SimpleError))
+        }
+
+        it("should not call the success closure") {
+          expect(result).to(beNil())
+        }
+      }
+
+      context("when one of the requests succeeds") {
+        beforeEach {
+          internalCache.promisesReturned[0].succeed("Test")
+        }
+
+        it("should not call the failure closure") {
+          expect(errors).to(beEmpty())
+        }
+
+        it("should not call the success closure") {
+          expect(result).to(beNil())
+        }
+      }
+
+      context("when all of the requests succeed") {
+        beforeEach {
+          internalCache.promisesReturned.enumerate().forEach { (iteration, promise) in
+            promise.succeed("\(iteration)")
+          }
+        }
+
+        it("should not call the failure closure") {
+          expect(errors).to(beEmpty())
+        }
+
+        it("should call the success closure") {
+          expect(result).notTo(beNil())
+        }
+
+        it("should pass all the values") {
+          expect(result.count).to(equal(internalCache.promisesReturned.count))
+        }
+
+        it("should pass the individual results in the right order") {
+          expect(result).to(equal(internalCache.promisesReturned.enumerate().map { (iteration, _) in
+            "\(iteration)"
+            }))
+        }
+      }
+
+      context("when one of the requests is canceled") {
+        beforeEach {
+          internalCache.promisesReturned[0].cancel()
+        }
+
+        it("should not call the success closure") {
+          expect(result).to(beNil())
+        }
+
+        it("should call the onCancel closure") {
+          expect(canceled).to(beTrue())
+        }
+      }
+
+      context("when the resulting request is canceled") {
+        beforeEach {
+          resultingFuture.cancel()
+        }
+
+        it("should cancel all the underlying requests") {
+          var canceledCount = 0
+          internalCache.promisesReturned.forEach { promise in
+            promise.onCancel {
+              canceledCount += 1
+            }
+          }
+
+          expect(canceledCount).to(equal(internalCache.promisesReturned.count))
+        }
+      }
+    }
+  }
+}
+
 class BatchTests: QuickSpec {
   override func spec() {
     let requestsCount = 5


### PR DESCRIPTION
See #154 

For some reason I couldn't the get the test setup properly in a new file, so I just stuck the tests in the `BatchTests.swift` file.

Since this is just a reification of `batchGetAll` I reused the same tests from BatchTests just tweaking slightly to fit the new API.

It probably also makes sense to deprecate `batchGetAll` if you agree this is a useful change.