### PR TITLE
Improve MacOS support Fix #62

### DIFF
--- a/Carlos.xcodeproj/project.pbxproj
+++ b/Carlos.xcodeproj/project.pbxproj
@@ -283,6 +283,8 @@
 		ADEA049E1E014326005BF920 /* PiedPiper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52B29CEB1CEA228800B5B277 /* PiedPiper.framework */; };
 		ADEA04A11E0143C9005BF920 /* PiedPiper.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 52B29CEB1CEA228800B5B277 /* PiedPiper.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		ADEA04A21E0143CC005BF920 /* PiedPiper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52B29CEB1CEA228800B5B277 /* PiedPiper.framework */; };
+		C4A297CD1E534EEF0015B9C7 /* ImageTransformer+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7620E1BB84EFF0087CD91 /* ImageTransformer+iOS.swift */; };
+		C4A297CF1E5355E60015B9C7 /* MemoryWarning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52635A471B4F0F6F00F187EE /* MemoryWarning.swift */; };
 		C71C59751B6A722800AE5294 /* NetworkFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71C59731B6A721C00AE5294 /* NetworkFetcherTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -1160,7 +1162,7 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = WeltN24;
 				TargetAttributes = {
 					5216CD0B1BC04B43005B729F = {
@@ -1434,6 +1436,7 @@
 				52CF0AA91B9203B30061022D /* Composed.swift in Sources */,
 				52CF0AAA1B9203B30061022D /* Conditioned.swift in Sources */,
 				52CF0AAC1B9203B30061022D /* DiskCacheLevel.swift in Sources */,
+				C4A297CD1E534EEF0015B9C7 /* ImageTransformer+iOS.swift in Sources */,
 				52CF0AAD1B9203B30061022D /* Errors.swift in Sources */,
 				52CF0AAE1B9203B30061022D /* Extensions.swift in Sources */,
 				52CF0AAF1B9203B30061022D /* Logger.swift in Sources */,
@@ -1449,6 +1452,7 @@
 				52CF0AB81B9203B30061022D /* KeyTransformation.swift in Sources */,
 				520DBB601CF6322E00F9ABE3 /* BatchAllCache.swift in Sources */,
 				52CF0AB91B9203B30061022D /* RequestCapperCache.swift in Sources */,
+				C4A297CF1E5355E60015B9C7 /* MemoryWarning.swift in Sources */,
 				AD8558111BA94FF10054FB5F /* NSKeyedUnarchiver+SwiftUtilities.m in Sources */,
 				52CF0AC11B9204730061022D /* ExpensiveObject+Mac.swift in Sources */,
 				5222108D1C501F2100E682D1 /* ConditionedTwoWayTransformer.swift in Sources */,
@@ -1785,7 +1789,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "de.weltn24.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1857,13 +1861,13 @@
 				INFOPLIST_FILE = CarlosMac/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = de.weltn24.CarlosMac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1890,13 +1894,13 @@
 				INFOPLIST_FILE = CarlosMac/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = de.weltn24.CarlosMac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 2.3;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1996,7 +2000,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -2061,7 +2065,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Carlos/CacheProvider+iOS.swift
+++ b/Carlos/CacheProvider+iOS.swift
@@ -1,16 +1,15 @@
 import Foundation
-import UIKit
 
 extension CacheProvider {
   /// A shared image cache instance
-  public static let sharedImageCache: BasicCache<URL, UIImage> = CacheProvider.imageCache()
+  public static let sharedImageCache: BasicCache<URL, CarlosImage> = CacheProvider.imageCache()
   
   /**
   - returns: An initialized and configured CacheLevel that takes NSURL keys and stores UIImage values. Network requests are pooled for efficiency. Keep in mind that calling this method twice returns two different instances. You should take care of retaining the result or use `sharedImageCache` instead
   */
-  public static func imageCache() -> BasicCache<URL, UIImage> {
-    return MemoryCacheLevel<URL, UIImage>()
-      .compose(DiskCacheLevel<URL, UIImage>())
+  public static func imageCache() -> BasicCache<URL, CarlosImage> {
+    return MemoryCacheLevel<URL, CarlosImage>()
+      .compose(DiskCacheLevel<URL, CarlosImage>())
       .compose(
         NetworkFetcher()
           .pooled()

--- a/Carlos/MemoryWarning.swift
+++ b/Carlos/MemoryWarning.swift
@@ -7,17 +7,31 @@ extension CacheLevel where Self: AnyObject {
   - returns: The token that you should use later on to unsubscribe
   */
   public func listenToMemoryWarnings() -> NSObjectProtocol {
-    return NotificationCenter.default.addObserver(forName: NSNotification.Name.UIApplicationDidReceiveMemoryWarning, object: nil, queue: OperationQueue.main, using: { [weak self] _ in
-      self?.onMemoryWarning()
-    })
+    #if os(macOS)
+        let source = DispatchSource.makeMemoryPressureSource(eventMask: [.warning, .critical])
+        source.setEventHandler { [weak self] _ in
+            self?.onMemoryWarning()
+        }
+        return source
+    #else
+        return NotificationCenter.default.addObserver(forName: NSNotification.Name.UIApplicationDidReceiveMemoryWarning, object: nil, queue: OperationQueue.main, using: { [weak self] _ in
+            self?.onMemoryWarning()
+        })
+    #endif
   }
-}
 
-/**
-Removes the memory warning listener
+  /**
+  Removes the memory warning listener
 
-- parameter token: The token you got from the call to listenToMemoryWarning: previously
-*/
-public func unsubscribeToMemoryWarnings(_ token: NSObjectProtocol) {
-  NotificationCenter.default.removeObserver(token, name: NSNotification.Name.UIApplicationDidReceiveMemoryWarning, object: nil)
+  - parameter token: The token you got from the call to listenToMemoryWarning: previously
+  */
+  public func unsubscribeToMemoryWarnings(_ token: NSObjectProtocol) {
+  #if os(macOS)
+    if let source = token as? DispatchSource {
+        source.cancel()
+    }
+  #else
+    NotificationCenter.default.removeObserver(token, name: NSNotification.Name.UIApplicationDidReceiveMemoryWarning, object: nil)
+  #endif
+  }
 }

--- a/Carthage/Checkouts/PiedPiper/PiedPiperSample.xcodeproj/project.pbxproj
+++ b/Carthage/Checkouts/PiedPiper/PiedPiperSample.xcodeproj/project.pbxproj
@@ -19,7 +19,6 @@
 		52B29CFE1CEA23A000B5B277 /* Future+Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BED2DE1CE8718D002C045A /* Future+Filter.swift */; };
 		52B29CFF1CEA23A000B5B277 /* Future+FlatMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BED2DF1CE8718D002C045A /* Future+FlatMap.swift */; };
 		52B29D001CEA23A000B5B277 /* Future+Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BED2E01CE8718D002C045A /* Future+Map.swift */; };
-		52B29D011CEA23A000B5B277 /* Future+MergeAll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BED2E11CE8718D002C045A /* Future+MergeAll.swift */; };
 		52B29D021CEA23A000B5B277 /* Future+Recover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BED2E21CE8718D002C045A /* Future+Recover.swift */; };
 		52B29D031CEA23A000B5B277 /* Future+Reduce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BED2E31CE8718D002C045A /* Future+Reduce.swift */; };
 		52B29D041CEA23A000B5B277 /* Future+Traverse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BED2E41CE8718D002C045A /* Future+Traverse.swift */; };
@@ -85,6 +84,7 @@
 		52D3675F1D85E82700466A8A /* Future+FirstCompletedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D3675E1D85E82700466A8A /* Future+FirstCompletedTests.swift */; };
 		52F9281F1D734B4700E6D010 /* Future+Snooze.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F9281E1D734B4700E6D010 /* Future+Snooze.swift */; };
 		9710F1891CFE9C4400713D3B /* Future+MergeSome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9710F1881CFE9C4400713D3B /* Future+MergeSome.swift */; };
+		C4A297CE1E5353300015B9C7 /* Future+MergeAll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BED2E11CE8718D002C045A /* Future+MergeAll.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -520,8 +520,6 @@
 			files = (
 				52B29CFE1CEA23A000B5B277 /* Future+Filter.swift in Sources */,
 				52B29D041CEA23A000B5B277 /* Future+Traverse.swift in Sources */,
-				52B29D011CEA23A000B5B277 /* Future+MergeAll.swift in Sources */,
-				52B29D011CEA23A000B5B277 /* Future+MergeAll.swift in Sources */,
 				52D367581D85E1C400466A8A /* Future+Timeout.swift in Sources */,
 				52D367561D85E1C000466A8A /* Future+All.swift in Sources */,
 				52B29CFD1CEA23A000B5B277 /* Future.swift in Sources */,
@@ -541,6 +539,7 @@
 				52D367571D85E1C300466A8A /* Future+Snooze.swift in Sources */,
 				52B29D071CEA23A000B5B277 /* Promise.swift in Sources */,
 				52D367591D85E1C600466A8A /* Future+FirstCompleted.swift in Sources */,
+				C4A297CE1E5353300015B9C7 /* Future+MergeAll.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -659,11 +658,12 @@
 				INFOPLIST_FILE = "PiedPiper-Mac/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = de.weltn24.PiedPiper;
 				PRODUCT_NAME = PiedPiper;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -683,12 +683,13 @@
 				INFOPLIST_FILE = "PiedPiper-Mac/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = de.weltn24.PiedPiper;
 				PRODUCT_NAME = PiedPiper;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};


### PR DESCRIPTION
- Add memory warning support
- Add image cache support in CacheProvider

I think some files could be renamed
- ImageTransformer+iOS -> ImageTransformer
- CacheProvider+iOS -> CacheProvider+Image

compile with PiedPiper PR https://github.com/WeltN24/PiedPiper/pull/17