### PR TITLE
Make unsubscribeToMemoryWarnings global again

### DIFF
--- a/Carlos/MemoryWarning.swift
+++ b/Carlos/MemoryWarning.swift
@@ -19,19 +19,19 @@ extension CacheLevel where Self: AnyObject {
         })
     #endif
   }
+}
 
-  /**
-  Removes the memory warning listener
-
-  - parameter token: The token you got from the call to listenToMemoryWarning: previously
-  */
-  public func unsubscribeToMemoryWarnings(_ token: NSObjectProtocol) {
-  #if os(macOS)
-    if let source = token as? DispatchSource {
-        source.cancel()
-    }
-  #else
-    NotificationCenter.default.removeObserver(token, name: NSNotification.Name.UIApplicationDidReceiveMemoryWarning, object: nil)
-  #endif
-  }
+/**
+ Removes the memory warning listener
+ 
+ - parameter token: The token you got from the call to listenToMemoryWarning: previously
+ */
+public func unsubscribeToMemoryWarnings(_ token: NSObjectProtocol) {
+    #if os(macOS)
+        if let source = token as? DispatchSource {
+            source.cancel()
+        }
+    #else
+        NotificationCenter.default.removeObserver(token, name: NSNotification.Name.UIApplicationDidReceiveMemoryWarning, object: nil)
+    #endif
 }

--- a/Tests/MemoryWarningNotificationTests.swift
+++ b/Tests/MemoryWarningNotificationTests.swift
@@ -34,7 +34,7 @@ class MemoryWarningNotificationTests: QuickSpec {
         
         context("when unsubscribing later") {
           beforeEach {
-            cache.unsubscribeToMemoryWarnings(token)
+            unsubscribeToMemoryWarnings(token)
           }
           
           context("when posting memory warnings") {


### PR DESCRIPTION
In a previous PR unsubscribeToMemoryWarnings was removed from the global scope and added as an extension of CacheLevel. This PR reverts that change

Commit with the mistake: https://github.com/WeltN24/Carlos/commit/b3e4241f02b399ca9cced35299018e36f391b5cf